### PR TITLE
Allow markdown syntax for comment and post creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
 			<artifactId>ocpsoft-pretty-time</artifactId>
 			<version>1.0.7</version>
 		</dependency>
+		<dependency>
+			<groupId>com.vladsch.flexmark</groupId>
+			<artifactId>flexmark-all</artifactId>
+			<version>0.18.5</version>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/com/sysc4806/Comment.java
+++ b/src/main/java/com/sysc4806/Comment.java
@@ -85,7 +85,7 @@ public class Comment {
     public void addChild(Comment child) { children.add(child); }
     public List<Comment> getChildren() { return children; }
 
-    public void setContent(String content) { this.content = content; }
+    public void setContent(String content) { this.content = MarkdownTranslator.translate(content); }
     public String getContent() { return content; }
 
     public Post getPost() { return post; }

--- a/src/main/java/com/sysc4806/Comment.java
+++ b/src/main/java/com/sysc4806/Comment.java
@@ -43,6 +43,10 @@ public class Comment {
     @ManyToOne
     private Comment parent;
 
+    @Column(columnDefinition = "TEXT")
+    private String source;
+
+    @Column(columnDefinition = "TEXT")
     private String content;
     private int votes;
 
@@ -85,8 +89,9 @@ public class Comment {
     public void addChild(Comment child) { children.add(child); }
     public List<Comment> getChildren() { return children; }
 
-    public void setContent(String content) { this.content = MarkdownTranslator.translate(content); }
+    public void setContent(String content) { this.source = content; this.content = MarkdownTranslator.translate(content); }
     public String getContent() { return content; }
+    public String getSource() { return source; }
 
     public Post getPost() { return post; }
     public void setPost(Post post) { this.post = post; }

--- a/src/main/java/com/sysc4806/MarkdownTranslator.java
+++ b/src/main/java/com/sysc4806/MarkdownTranslator.java
@@ -1,0 +1,34 @@
+package com.sysc4806;
+
+import com.vladsch.flexmark.ast.Node;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.superscript.SuperscriptExtension;
+import com.vladsch.flexmark.util.options.MutableDataHolder;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+
+import java.util.Arrays;
+
+/**
+ * Created by rscar on 3/29/2017.
+ */
+public class MarkdownTranslator {
+    static final MutableDataHolder OPTIONS = new MutableDataSet()
+            .set(Parser.EXTENSIONS, Arrays.asList(
+                    TablesExtension.create(),
+                    StrikethroughExtension.create(),
+                    TaskListExtension.create(),
+                    SuperscriptExtension.create()
+            ));
+
+    public static String translate(String input) {
+        Parser parser = Parser.builder(OPTIONS).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(OPTIONS).build();
+
+        Node parsed = parser.parse(input);
+        return renderer.render(parsed);
+    }
+}

--- a/src/main/java/com/sysc4806/Post.java
+++ b/src/main/java/com/sysc4806/Post.java
@@ -40,6 +40,7 @@ public class Post {
     @ManyToOne
     private User poster;
 
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     private ArrayList<String> tags;
@@ -54,9 +55,9 @@ public class Post {
     public Post(String title, User poster, String description){
         this();
 
-        this.title = title;
-        this.poster = poster;
-        this.description = description;
+        setTitle(title);
+        setPoster(poster);
+        setDescription(description);
     }
 
     public Date getUpdated() { return updated; }

--- a/src/main/java/com/sysc4806/Post.java
+++ b/src/main/java/com/sysc4806/Post.java
@@ -97,7 +97,7 @@ public class Post {
         return description;
     }
     public void setDescription(String description){
-        this.description = description;
+        this.description = MarkdownTranslator.translate(description);
     }
 
     public void upVote() { votes ++; }

--- a/src/main/java/com/sysc4806/PostController.java
+++ b/src/main/java/com/sysc4806/PostController.java
@@ -60,6 +60,9 @@ public class PostController {
                              @RequestParam(value="description") String description,
                              @RequestParam(value="tags") String tags, Model model) {
 
+        if (title.trim().length() == 0)
+            throw new ResourceNotFoundException();
+
         Post p = new Post(title, AuthenticationController.CurrentUser(), description);
         ArrayList<String> tagsTrimmed = new ArrayList<>();
         //Check if tags is empty or all spaces

--- a/src/main/resources/templates/ama/new.html
+++ b/src/main/resources/templates/ama/new.html
@@ -4,20 +4,30 @@
 <head>...</head>
 <body>
 <div class="container" th:fragment="content">
-    <form action="/ama/new" method="post">
+    <form action="/ama/new" method="post" onsubmit="return title_not_empty()">
         <div class="form-group">
+            <div class="alert alert-danger alert-dismissible" role="alert" id="titleError" style="display:none;">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <strong>Error:</strong> Title cannot be empty
+            </div>
+
             <label for="title">Title</label><br/>
             <input type="text" class="form-control" id="title" name="title" placeholder="Title" />
         </div>
         <div class="form-group">
             <label for="description">Description</label><br/>
+            <small class="text-muted">
+                Markdown syntax is supported here. Click
+                <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank" rel="noopener">here</a>
+                for details.
+            </small>
             <textarea class="form-control" id="description" name="description" placeholder="Description" />
         </div>
         <div class="form-group">
             <label for="tags">Comma separated tags</label><br/>
             <input type="text" class="form-control" id="tags" name="tags" placeholder="Tags" />
         </div>
-        <button type="submit" class="btn btn-default">Submit</button>
+        <input type="submit" class="btn btn-default" />
     </form>
 </div>
 </body>

--- a/src/main/resources/templates/ama/view.html
+++ b/src/main/resources/templates/ama/view.html
@@ -11,7 +11,7 @@
                     <a class="text-muted" href="#" th:text="${'#'+tag}"></a>
                 </small>
             </div>
-            <div class="panel-body" th:if="${ama.description.length() > 0}" th:text="${ama.description}"></div>
+            <div class="panel-body" th:if="${ama.description.length() > 0}" th:utext="${ama.description}"></div>
             <div class="panel-footer">
                 <small class="text-muted">Submitted <span th:text="${ama.getFormattedCreated()}" th:remove="tag"></span> by
                     <span th:replace="fragments/user :: user(${ama.poster})"></span>

--- a/src/main/resources/templates/ama/view.html
+++ b/src/main/resources/templates/ama/view.html
@@ -23,7 +23,12 @@
         <form action="/comment/new" method="post">
             <input type="hidden" name="postID" th:value="${ama.id}" />
             <div class="form-group">
-                <textarea class="form-control" id="content" name="content" placeholder="Content" />
+                <small class="text-muted">
+                    Markdown syntax is supported here. Click
+                    <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank" rel="noopener">here</a>
+                    for details.
+                </small>
+                <textarea class="form-control" id="content" name="content" />
             </div>
             <button type="submit" class="btn btn-default">Comment</button>
         </form>

--- a/src/main/resources/templates/fragments/comment.html
+++ b/src/main/resources/templates/fragments/comment.html
@@ -7,7 +7,7 @@
     <div class="panel" th:classappend="${c.poster != null and post.poster.id == c.poster.id}?panel-primary:panel-default">
 
         <!-- comment body -->
-        <div class="panel-body" th:text="${c.content}" th:unless="${c.poster == null}"></div>
+        <div class="panel-body" th:utext="${c.content}" th:unless="${c.poster == null}"></div>
         <div class="panel-body text-muted text-center" th:if="${c.poster == null}">
             Comment Deleted
         </div>
@@ -30,7 +30,7 @@
                 <input type="hidden" name="postID" th:value="${post.id}" />
                 <input type="hidden" name="commentID" th:value="${c.id}" />
                 <div class="form-group">
-                    <textarea class="form-control" name="content" placeholder="Content" th:text="${c.content}"></textarea>
+                    <textarea class="form-control" name="content" placeholder="Content" th:text="${c.source}"></textarea>
                 </div>
                 <button type="submit" class="btn btn-default">Save</button>
             </form>

--- a/src/main/resources/templates/fragments/comment.html
+++ b/src/main/resources/templates/fragments/comment.html
@@ -13,24 +13,36 @@
         </div>
 
         <!-- Reply box -->
-        <div class="panel-body collapse" th:id="${'replycollapse'+c.id}">
+        <div class="panel-footer collapse" role="tabpanel" th:id="${'replycollapse'+c.id}">
+            <h4>Reply to comment</h4>
             <form action="/comment/new" method="post">
                 <input type="hidden" name="postID" th:value="${post.id}" />
                 <input type="hidden" name="parentID" th:value="${c.id}" />
                 <div class="form-group">
-                    <textarea class="form-control" id="content" name="content" placeholder="Content" />
+                    <small class="text-muted">
+                        Markdown syntax is supported here. Click
+                        <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank" rel="noopener">here</a>
+                        for details.
+                    </small>
+                    <textarea class="form-control" id="content" name="content" />
                 </div>
                 <button type="submit" class="btn btn-default">Reply</button>
             </form>
         </div>
 
         <!-- Edit box -->
-        <div th:unless="${c.poster == null}" class="panel-body collapse" th:id="${'editcollapse'+c.id}">
+        <div th:unless="${c.poster == null}" role="tabpanel" class="panel-footer collapse" th:id="${'editcollapse'+c.id}">
+            <h4>Edit comment</h4>
             <form action="/comment/edit" method="post">
                 <input type="hidden" name="postID" th:value="${post.id}" />
                 <input type="hidden" name="commentID" th:value="${c.id}" />
                 <div class="form-group">
-                    <textarea class="form-control" name="content" placeholder="Content" th:text="${c.source}"></textarea>
+                    <small class="text-muted">
+                        Markdown syntax is supported here. Click
+                        <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank" rel="noopener">here</a>
+                        for details.
+                    </small>
+                    <textarea class="form-control" name="content" th:text="${c.source}"></textarea>
                 </div>
                 <button type="submit" class="btn btn-default">Save</button>
             </form>

--- a/src/main/resources/templates/layouts/default.html
+++ b/src/main/resources/templates/layouts/default.html
@@ -25,6 +25,15 @@
             $.get(url);
             reload();
         }
+
+        function title_not_empty() {
+            if ($("#title").val().trim().length == 0) {
+                $("#titleError").css("display", "");
+                return false;
+            }
+
+            return true;
+        }
     </script>
 
     <title th:text="${title}"></title>

--- a/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
+++ b/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
@@ -25,10 +25,10 @@ public class MarkdownTranslatorTest {
     @Test
     public void testSuperscript() {
         Assert.assertEquals("<p><sup>test</sup></p>\n",
-                MarkdownTranslator.translate("^test"));
+                MarkdownTranslator.translate("^test^"));
 
         Assert.assertEquals("<p><sup><sup>test</sup></sup></p>\n",
-                MarkdownTranslator.translate("^^test"));
+                MarkdownTranslator.translate("^^test^^"));
     }
 
     @Test

--- a/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
+++ b/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
@@ -23,6 +23,15 @@ public class MarkdownTranslatorTest {
     }
 
     @Test
+    public void testSuperscript() {
+        Assert.assertEquals("<p><sup>test</sup></p>\n",
+                MarkdownTranslator.translate("^test"));
+
+        Assert.assertEquals("<p><sup><sup>test</sup></sup></p>\n",
+                MarkdownTranslator.translate("^^test"));
+    }
+
+    @Test
     public void testLinks() {
         Assert.assertEquals("<p><a href=\"#\">test</a></p>\n",
                 MarkdownTranslator.translate("[test](#)"));

--- a/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
+++ b/src/test/java/com/sysc4806/MarkdownTranslatorTest.java
@@ -1,0 +1,30 @@
+package com.sysc4806;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by rscar on 3/29/2017.
+ */
+public class MarkdownTranslatorTest {
+    @Test
+    public void testStrikethrough() {
+        Assert.assertEquals("<p><del>test</del></p>\n",
+                MarkdownTranslator.translate("~~test~~"));
+    }
+
+    @Test
+    public void testParagraphs() {
+        Assert.assertEquals("<p>test</p>\n",
+                MarkdownTranslator.translate("test"));
+
+        Assert.assertEquals("<p>test</p>\n<p>test</p>\n",
+                MarkdownTranslator.translate("test\n\ntest"));
+    }
+
+    @Test
+    public void testLinks() {
+        Assert.assertEquals("<p><a href=\"#\">test</a></p>\n",
+                MarkdownTranslator.translate("[test](#)"));
+    }
+}


### PR DESCRIPTION
You can now use [markdown syntax](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) when posting and commenting, similar to that used on reddit and github

Fixes #66 